### PR TITLE
Increase additional storage to 100GB

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ module "aws_deploy-main-ap-southeast-1" {
   root_volume_size = 40
 
   additional_storage      = 1
-  additional_storage_size = 30
+  additional_storage_size = 100
 
   aeternity = {
     package = var.package
@@ -41,7 +41,7 @@ module "aws_deploy-main-eu-north-1" {
   root_volume_size = 40
 
   additional_storage      = 1
-  additional_storage_size = 30
+  additional_storage_size = 100
 
   aeternity = {
     package = var.package
@@ -70,7 +70,7 @@ module "aws_deploy-main-us-west-2" {
   root_volume_size = 40
 
   additional_storage      = 1
-  additional_storage_size = 30
+  additional_storage_size = 100
 
   aeternity = {
     package = var.package
@@ -97,7 +97,7 @@ module "aws_deploy-main-us-east-2" {
   root_volume_size = 40
 
   additional_storage      = 1
-  additional_storage_size = 30
+  additional_storage_size = 100
 
   aeternity = {
     package = var.package


### PR DESCRIPTION
30 GB was no longer enough to create and restore backups. This increases only the reserved volume sizes of AWS. 
Actual increase of usable space of existing instances is done by https://github.com/aeternity/infrastructure/pull/417
it is run manually

in scope of https://www.pivotaltracker.com/story/show/168429919

Changes are applied, so plan should not show diffs